### PR TITLE
Skip PR with skip changelog

### DIFF
--- a/antsichaut/antsichaut.py
+++ b/antsichaut/antsichaut.py
@@ -259,7 +259,7 @@ class ChangelogCIBase:
         leftover_changes = []
 
         skip_labels = self.group_config.pop(
-            [i for i, d in enumerate(self.group_config) if d["title"] == "skip_changelog"][0]
+            [i for i, d in enumerate(self.group_config) if d["title"] == "skip_changelog"][0],
         )["labels"]
 
         for pull_request in changes:

--- a/antsichaut/antsichaut.py
+++ b/antsichaut/antsichaut.py
@@ -257,12 +257,16 @@ class ChangelogCIBase:
         )
 
         leftover_changes = []
+
+        skip_labels = [
+            cfg["labels"] for cfg in self.group_config if cfg["title"] == "skip_changelog"
+        ][0]
         for pull_request in changes:
             for config in self.group_config:
                 if any(label in pull_request["labels"] for label in config["labels"]):
                     # if a PR contains a skip changelog label,
                     # do not add it to the changelog
-                    if config["title"] in ["skip_changelog", "skip-changelog", "skipchangelog"]:
+                    if any(label in pull_request["labels"] for label in skip_labels):
                         break
 
                     change_type = config["title"]
@@ -473,7 +477,7 @@ def main() -> None:
         dest="skip_changelog_labels",
         type=str,
         action="append",
-        help="the labels for skip_changelog. Default: ['skip_changelog']",
+        help="the labels for skip_changelog. Default: ['skip_changelog', 'skip-changelog', 'skipchangelog']",
         env_var="SKIP_CHANGELOG_LABELS",
         required=False,
     )
@@ -500,7 +504,7 @@ def main() -> None:
     if not args.bugfixes_labels:
         args.bugfixes_labels = ["bug", "bugfix"]
     if not args.skip_changelog_labels:
-        args.skip_changelog_labels = ["skip_changelog"]
+        args.skip_changelog_labels = ["skip_changelog", "skip-changelog", "skipchangelog"]
 
     repository = args.repository
     since_version = args.since_version

--- a/antsichaut/antsichaut.py
+++ b/antsichaut/antsichaut.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 from functools import cached_property
 from importlib.metadata import version as _version
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, Sequence
 
 import configargparse
 import requests
@@ -39,7 +39,7 @@ class ChangelogCIBase:
         repository: str,
         since_version: str,
         to_version: str,
-        group_config: list[dict[str, str]],
+        group_config: list[dict[str, Sequence[str]]],
         filename: str = "changelogs/changelog.yaml",
         token: Optional[str] = None,
     ) -> None:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -22,7 +22,7 @@ GROUP_CONFIG = [
     {
         "title": "skip_changelog",
         "labels": ["skip_changelog", "skip-changelog", "skipchangelog"],
-    }
+    },
 ]
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -18,6 +18,12 @@ if TYPE_CHECKING:
 
 REPO = "ansible-community/antsichaut"
 FIXTURE_DIR = Path(__file__).parent / "fixtures"
+GROUP_CONFIG = [
+    {
+        "title": "skip_changelog",
+        "labels": ["skip_changelog", "skip-changelog", "skipchangelog"],
+    }
+]
 
 
 def test_failure(capsys: pytest.CaptureFixture[str]) -> None:
@@ -29,7 +35,7 @@ def test_failure(capsys: pytest.CaptureFixture[str]) -> None:
         repository=REPO,
         since_version="0.0.0",
         to_version="",
-        group_config=[],
+        group_config=GROUP_CONFIG,
     )
     cci.run()
     captured = capsys.readouterr()
@@ -86,7 +92,7 @@ def test_success(monkeypatch: pytest.MonkeyPatch) -> None:
         repository=REPO,
         since_version="0.3.2",
         to_version="0.3.5",
-        group_config=[],
+        group_config=GROUP_CONFIG,
         token=token,
     )
     cci.run()


### PR DESCRIPTION
Looking closer, #31 was incomplete.

We can skip a PR entirely if it has a skip changelog label. Pop the skip-changlog entry from the group config and look early for a match.

Compare the labels of the PR to the provided or default skip changelog and move onto the next PR if we have a match.

- update defaults for help as well

