### PR TITLE
Order releases by semver

### DIFF
--- a/antsichaut/antsichaut.py
+++ b/antsichaut/antsichaut.py
@@ -226,15 +226,22 @@ class ChangelogCIBase:
                         del current_changes[change_type][idx]
 
     @staticmethod
-    def _sort_by_semver(releases: dict) -> dict:
+    def _sort_by_semver(data: ChLogType) -> ChLogType:
         """Sort releases by semver.
 
-        :param releases: The releases to sort
+        :param data: The full changelog structure
         :return: The sorted releases
         """
-        return OrderedDict(
-            sorted(releases.items(), key=lambda t: [int(v) for v in t[0].split(".")], reverse=True)
+        if not data or "releases" not in data:
+            return data
+        data["releases"] = OrderedDict(
+            sorted(
+                data["releases"].items(),
+                key=lambda t: [int(v) for v in t[0].split(".")],
+                reverse=True,
+            ),
         )
+        return data
 
     def parse_changelog(  # noqa: C901, PLR0912
         self,
@@ -254,8 +261,7 @@ class ChangelogCIBase:
 
         # get the new version from the changelog.yaml
         # by using the last item in the list of releases
-        # sort the releases by version number, semver is assumed here
-        data["releases"] = self._sort_by_semver(data["releases"])
+        data = self._sort_by_semver(data)
         new_version = list(data["releases"].keys())[0]
 
         # add changes-key to the release dict

--- a/antsichaut/antsichaut.py
+++ b/antsichaut/antsichaut.py
@@ -225,6 +225,17 @@ class ChangelogCIBase:
                     if url_found and not_full_match:
                         del current_changes[change_type][idx]
 
+    @staticmethod
+    def _sort_by_semver(releases: dict) -> dict:
+        """Sort releases by semver.
+
+        :param releases: The releases to sort
+        :return: The sorted releases
+        """
+        return OrderedDict(
+            sorted(releases.items(), key=lambda t: [int(v) for v in t[0].split(".")], reverse=True)
+        )
+
     def parse_changelog(  # noqa: C901, PLR0912
         self,
         changes: list[dict[str, str]],
@@ -243,7 +254,9 @@ class ChangelogCIBase:
 
         # get the new version from the changelog.yaml
         # by using the last item in the list of releases
-        new_version = list(dict(dict(data)["releases"]))[-1]
+        # sort the releases by version number, semver is assumed here
+        data["releases"] = self._sort_by_semver(data["releases"])
+        new_version = list(data["releases"].keys())[0]
 
         # add changes-key to the release dict
         dict(data)["releases"][new_version].insert(0, "changes", {})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,8 @@ disable = [
   "fixme",
   "too-few-public-methods",
   "unsubscriptable-object",
+  "protected-access", # covered  by ruff
+
 ]
 enable = [
   "useless-suppression", # Identify unneeded pylint disable statements
@@ -106,7 +108,8 @@ target-version = "py38"
 
 [tool.ruff.per-file-ignores]
 # S101 allow assert in tests
-"tests/**" = ["S101"]
+# SLF001 allow private access in tests
+"tests/**" = ["S101", "SLF001"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/fixtures/changelogs/changelog.yaml
+++ b/tests/fixtures/changelogs/changelog.yaml
@@ -3,3 +3,12 @@ releases:
   1.0.0:
     changes:
       trivial: []
+  1.0.10:
+    changes:
+      trivial: []
+  1.0.11:
+    changes:
+      trivial: []
+  1.0.2:
+    changes:
+      trivial: []

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -110,7 +110,7 @@ def test_success(monkeypatch: pytest.MonkeyPatch) -> None:
     assert re.findall(r"pull/(\d+)", cci.test_str_data) == ["12", "11", "10"]
 
 
-def test_sort_semver():
+def test_sort_semver() -> None:
     """Test sorting by semver."""
     cci = ChangelogCIBase(
         repository=REPO,
@@ -126,8 +126,7 @@ def test_sort_semver():
 
     original = list(data["releases"].keys())
 
-    data["releases"] = cci._sort_by_semver(data["releases"])  # pylint: disable=protected-access
-
+    data = cci._sort_by_semver(data)
     revised = list(data["releases"].keys())
 
     assert original != revised


### PR DESCRIPTION
This will ensure releases are always ordered most recent to oldest in the changelog.yaml file.

Should prevent problems like this:

https://github.com/ansible-collections/ansible.scm/blob/main/changelogs/changelog.yaml

where 1.0.10 falls alphabetically before 1.0.9

