### PR TITLE
Account for release summary

### DIFF
--- a/antsichaut/antsichaut.py
+++ b/antsichaut/antsichaut.py
@@ -344,7 +344,9 @@ class ChangelogCIBase:
         for _release_number, release_changes in self._string_data["releases"].items():
             if "changes" not in release_changes:
                 continue
-            for _change_type, changes in release_changes["changes"].items():
+            for change_type, changes in release_changes["changes"].items():
+                if not isinstance(changes, list):
+                    continue
                 changes.sort(
                     key=self._extract_pr_number_from_url,
                     reverse=True,

--- a/antsichaut/antsichaut.py
+++ b/antsichaut/antsichaut.py
@@ -344,7 +344,7 @@ class ChangelogCIBase:
         for _release_number, release_changes in self._string_data["releases"].items():
             if "changes" not in release_changes:
                 continue
-            for change_type, changes in release_changes["changes"].items():
+            for _change_type, changes in release_changes["changes"].items():
                 if not isinstance(changes, list):
                     continue
                 changes.sort(


### PR DESCRIPTION
In the case a release summary is present in the changes key of the changelog it will be a string and not a list:

```
2.6.1:
    changes:
      release_summary: Rereleased 2.6.0 with fixes for internal testing.
```

Fixes: https://github.com/ansible-collections/ansible.utils/actions/runs/4993274628/jobs/8942149097